### PR TITLE
Draft - Child Resource UI Extensions Support

### DIFF
--- a/docs/developer-guide/extensions/ui-extensions.md
+++ b/docs/developer-guide/extensions/ui-extensions.md
@@ -30,7 +30,7 @@ Resource Tab extensions is an extension that provides an additional tab for the 
 The resource tab extension should be registered using the `extensionsAPI.registerResourceExtension` method:
 
 ```typescript
-registerResourceExtension(component: ExtensionComponent, group: string, kind: string, tabTitle: string)
+registerResourceExtension(component: ExtensionComponent, group: string, kind: string, tabTitle: string, opts?: {icon?: string; matchOnAncestors?: boolean})
 ```
 
 - `component: ExtensionComponent` is a React component that receives the following properties:
@@ -46,6 +46,7 @@ registerResourceExtension(component: ExtensionComponent, group: string, kind: st
 - `tabTitle: string` - the extension tab title.
 - `opts: Object` - additional options:
   - `icon: string` - the class name the represents the icon from the [https://fontawesome.com/](https://fontawesome.com/) library (e.g. 'fa-calendar-alt');
+  - `matchOnAncestors: boolean` - when true, the extension tab also appears when the selected resource is a descendant of a resource matching group/kind (e.g. a Rollout extension will show for Rollout, ReplicaSet, and Pod when viewing any of them).
 
 Below is an example of a resource tab extension:
 
@@ -59,6 +60,23 @@ Below is an example of a resource tab extension:
     "*",
     "*",
     "Nice extension"
+  );
+})(window);
+```
+
+Example with `matchOnAncestors` for an Argo Rollouts extension (shows tab when viewing Rollout, ReplicaSet, or Pod):
+
+```javascript
+((window) => {
+  const component = (props) => {
+    return React.createElement("div", {}, "Rollout Details");
+  };
+  window.extensionsAPI.registerResourceExtension(
+    component,
+    "argoproj.io",
+    "Rollout",
+    "Rollout",
+    { icon: "fa fa-sync-alt", matchOnAncestors: true }
   );
 })(window);
 ```

--- a/docs/plans/2025-02-24-ui-extensions-child-resource-activation-design.md
+++ b/docs/plans/2025-02-24-ui-extensions-child-resource-activation-design.md
@@ -1,0 +1,95 @@
+# UI Extensions: Child Resource Activation — Design
+
+**Date:** 2025-02-24
+
+## Summary
+
+Expand Resource Tab UI extensions to support activation when the selected resource is a descendant of a resource matching the extension's group/kind. Maintain full backwards compatibility with existing extensions.
+
+## Requirements (Validated)
+
+- **Activation mode:** Extension activates when the selected resource has an ancestor matching the extension's group/kind (any ancestor, not just direct parent).
+- **Combined matching:** Extension activates when EITHER (a) the resource matches group/kind directly, OR (b) the resource has an ancestor matching group/kind.
+- **Backwards compatibility:** Existing extensions (no new opts) behave exactly as today.
+- **Opt-in:** New behavior is opt-in via `matchOnAncestors: true` in opts.
+
+## API Changes
+
+### 1. `registerResourceExtension`
+
+Extend the optional `opts` parameter:
+
+```typescript
+registerResourceExtension(
+  component: ExtensionComponent,
+  group: string,
+  kind: string,
+  tabTitle: string,
+  opts?: { icon?: string; matchOnAncestors?: boolean }
+)
+```
+
+### 2. `ResourceTabExtension` interface
+
+```typescript
+export interface ResourceTabExtension {
+  title: string;
+  group: string;
+  kind: string;
+  component: ExtensionComponent;
+  icon?: string;
+  matchOnAncestors?: boolean;
+}
+```
+
+### 3. `getResourceTabs` signature
+
+```typescript
+getResourceTabs(
+  group: string,
+  kind: string,
+  tree?: ApplicationTree,
+  selectedNode?: ResourceNode
+): ResourceTabExtension[]
+```
+
+When `tree` and `selectedNode` are omitted, only direct matching applies (backwards compatible).
+
+## Matching Logic
+
+For each extension:
+
+1. **Direct match:** `minimatch(selectedNode.group, ext.group) && minimatch(selectedNode.kind, ext.kind)` — unchanged.
+2. **Ancestor match:** When `ext.matchOnAncestors === true` and `tree` and `selectedNode` are provided, traverse ancestors via `parentRefs`, resolving each parent from `tree.nodes` and `tree.orphanedNodes`. Extension matches if any ancestor matches `ext.group` and `ext.kind`.
+
+Helper: `hasAncestorMatching(node, tree, group, kind)` — walks parent chain, uses `nodeKey()` for lookups, includes orphaned nodes.
+
+## Data Flow
+
+| Call site | Change |
+|-----------|--------|
+| `resource-details.tsx` (resource panel) | Add `tree, selectedNode` to `getResourceTabs` |
+| `resource-details.tsx` (Application tabs) | No change |
+| `appset-resource-details.tsx` | No change |
+
+## Edge Cases
+
+| Case | Handling |
+|------|----------|
+| No `parentRefs` | Ancestor match fails; direct match only |
+| Parent not found in tree | Skip; continue with others |
+| Circular refs | Track visited keys; stop if seen twice |
+| `tree` or `selectedNode` null | Skip ancestor matching |
+| Orphaned nodes | Include `orphanedNodes` when resolving parents |
+
+## Error Handling
+
+- Ancestor traversal is synchronous; no async or external calls.
+- If traversal throws, catch in `getResourceTabs` and fall back to direct match only.
+- Extensions unchanged; no new error paths in extension code.
+
+## Testing
+
+- Unit tests for `getResourceTabs` / ancestor helper: direct match, ancestor match, both, missing parent, circular refs, omitted tree/node.
+- Integration: manual verification with Rollout-style extension.
+- Docs: update `docs/developer-guide/extensions/ui-extensions.md` with `matchOnAncestors` and example.

--- a/docs/plans/2025-02-24-ui-extensions-child-resource-activation.md
+++ b/docs/plans/2025-02-24-ui-extensions-child-resource-activation.md
@@ -1,0 +1,166 @@
+# UI Extensions: Child Resource Activation — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `matchOnAncestors` opt-in to Resource Tab extensions so they activate when the selected resource is a descendant of a resource matching the extension's group/kind, while preserving full backwards compatibility.
+
+**Architecture:** Extend `registerResourceExtension` opts with `matchOnAncestors?: boolean`. When true, `getResourceTabs` also matches extensions when any ancestor of the selected node matches group/kind. Add optional `tree` and `selectedNode` params to `getResourceTabs`; when provided, ancestor traversal runs. Use `parentRefs` to walk the tree; resolve parents from `nodes` and `orphanedNodes`.
+
+**Tech Stack:** TypeScript, React, minimatch, Argo CD UI models (ApplicationTree, ResourceNode, ResourceRef)
+
+**Design doc:** `docs/plans/2025-02-24-ui-extensions-child-resource-activation-design.md`
+
+---
+
+## Task 1: Add `hasAncestorMatching` helper
+
+**Files:**
+- Create: `ui/src/app/shared/services/extensions-service-helpers.ts`
+- Modify: `ui/src/app/shared/services/extensions-service.ts`
+
+**Step 1: Create helper module**
+
+Create `extensions-service-helpers.ts` with:
+- `nodeKey(ref: {group: string; kind: string; namespace: string; name: string}): string` — returns `[group, kind, namespace, name].join('/')`
+- `hasAncestorMatching(node: ResourceNode, tree: ApplicationTree, group: string, kind: string): boolean` — builds `nodeByKey` from `tree.nodes` and `tree.orphanedNodes`, walks `node.parentRefs` recursively, returns true if any ancestor matches via minimatch; tracks visited keys to avoid circular refs; skips missing parents
+
+**Step 2: Update getResourceTabs in extensions-service**
+
+Import the helper. Change `getResourceTabs(group, kind)` to `getResourceTabs(group, kind, tree?, selectedNode?)`. When `tree` and `selectedNode` provided, for extensions with `matchOnAncestors === true`, also include if `hasAncestorMatching(...)` (wrap in try/catch). Filter: include if direct match OR (matchOnAncestors && ancestor match).
+- Builds a `nodeByKey` map from `tree.nodes` and `tree.orphanedNodes`
+- Walks `node.parentRefs` recursively, resolving each parent via `nodeByKey`
+- Returns true if any ancestor matches `minimatch(ancestor.group, group) && minimatch(ancestor.kind, kind)`
+- Tracks visited keys to avoid circular refs
+- Returns false if parent not found (skip and continue)
+
+Update `getResourceTabs(group, kind, tree?, selectedNode?)`:
+- When `tree` and `selectedNode` are provided, for each extension with `matchOnAncestors === true`, also include if `hasAncestorMatching(selectedNode, tree, ext.group, ext.kind)` (wrap in try/catch, fallback to direct match only on error)
+- Filter logic: include extension if direct match OR (matchOnAncestors && ancestor match)
+
+**Step 2: Run existing tests**
+
+Run: `cd ui && npm test -- --testPathIgnorePatterns=node_modules --passWithNoTests 2>/dev/null || true`
+Expected: No new failures (extensions-service has no existing tests)
+
+**Step 3: Commit**
+
+```bash
+git add ui/src/app/shared/services/extensions-service.ts
+git commit -m "feat(ui): add ancestor matching support to getResourceTabs"
+```
+
+---
+
+## Task 2: Extend registerResourceExtension opts and ResourceTabExtension interface
+
+**Files:**
+- Modify: `ui/src/app/shared/services/extensions-service.ts`
+
+**Step 1: Update registerResourceExtension and interface**
+
+- Change `opts?: {icon: string}` to `opts?: {icon?: string; matchOnAncestors?: boolean}`
+- Add `matchOnAncestors?: boolean` to `ResourceTabExtension` interface
+- In `registerResourceExtension`, pass `matchOnAncestors: opts?.matchOnAncestors` into the extension object
+
+**Step 2: Commit**
+
+```bash
+git add ui/src/app/shared/services/extensions-service.ts
+git commit -m "feat(ui): add matchOnAncestors opt to registerResourceExtension"
+```
+
+---
+
+## Task 3: Update resource-details call site
+
+**Files:**
+- Modify: `ui/src/app/applications/components/resource-details/resource-details.tsx`
+
+**Step 1: Pass tree and selectedNode to getResourceTabs**
+
+Find the call around line 236:
+```typescript
+const extensions = selectedNode?.kind ? services.extensions.getResourceTabs(selectedNode?.group || '', selectedNode?.kind) : [];
+```
+
+Change to:
+```typescript
+const extensions = selectedNode?.kind ? services.extensions.getResourceTabs(selectedNode?.group || '', selectedNode?.kind, tree, selectedNode) : [];
+```
+
+**Step 2: Run tests**
+
+Run: `cd ui && npm test -- --testPathIgnorePatterns=node_modules 2>&1 | head -80`
+Expected: Tests pass
+
+**Step 3: Commit**
+
+```bash
+git add ui/src/app/applications/components/resource-details/resource-details.tsx
+git commit -m "feat(ui): pass tree and selectedNode to getResourceTabs for ancestor matching"
+```
+
+---
+
+## Task 4: Add unit tests for ancestor matching
+
+**Files:**
+- Create: `ui/src/app/shared/services/extensions-service-helpers.test.ts`
+
+**Step 1: Write tests for hasAncestorMatching**
+
+Create test file that imports `hasAncestorMatching` from `extensions-service-helpers` and tests:
+- Returns true when direct parent matches group/kind
+- Returns true when ancestor two levels up matches
+- Returns false when no ancestor matches
+- Returns false when node has no parentRefs
+- Handles missing parent in tree (skip, continue)
+- Handles circular parentRefs (track visited, return false to avoid infinite loop)
+- Includes orphanedNodes when building nodeByKey
+
+Use minimal ResourceNode and ApplicationTree fixtures (group, kind, namespace, name, parentRefs, nodes, orphanedNodes).
+
+**Step 2: Run tests**
+
+Run: `cd ui && npm test -- extensions-service-helpers.test.ts -v`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add ui/src/app/shared/services/extensions-service-helpers.test.ts
+git commit -m "test(ui): add unit tests for hasAncestorMatching"
+```
+
+---
+
+## Task 5: Update UI extensions documentation
+
+**Files:**
+- Modify: `docs/developer-guide/extensions/ui-extensions.md`
+
+**Step 1: Document matchOnAncestors**
+
+In the Resource Tab Extensions section, update the `registerResourceExtension` signature and opts:
+- Add `matchOnAncestors?: boolean` to opts
+- Add 1–2 sentence description: when true, extension also activates when the selected resource has an ancestor matching group/kind
+- Add a short example showing Rollout extension with `matchOnAncestors: true` so it shows for Rollout, ReplicaSet, and Pod
+
+**Step 2: Commit**
+
+```bash
+git add docs/developer-guide/extensions/ui-extensions.md
+git commit -m "docs: document matchOnAncestors for Resource Tab extensions"
+```
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/plans/2025-02-24-ui-extensions-child-resource-activation.md`. Two execution options:
+
+**1. Subagent-Driven (this session)** — I dispatch fresh subagent per task, review between tasks, fast iteration
+
+**2. Parallel Session (separate)** — Open new session with executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/ui/src/app/applications/components/resource-details/resource-details.tsx
+++ b/ui/src/app/applications/components/resource-details/resource-details.tsx
@@ -233,7 +233,7 @@ export const ResourceDetails = (props: ResourceDetailsProps) => {
         return tabs.concat(extensionTabs);
     };
 
-    const extensions = selectedNode?.kind ? services.extensions.getResourceTabs(selectedNode?.group || '', selectedNode?.kind) : [];
+    const extensions = selectedNode?.kind ? services.extensions.getResourceTabs(selectedNode?.group || '', selectedNode?.kind, tree, selectedNode) : [];
 
     return (
         <div style={{width: '100%', height: '100%'}}>

--- a/ui/src/app/shared/services/extensions-service-helpers.test.ts
+++ b/ui/src/app/shared/services/extensions-service-helpers.test.ts
@@ -1,0 +1,123 @@
+import {ApplicationTree, ResourceNode} from '../models';
+import {hasAncestorMatching, nodeKey} from './extensions-service-helpers';
+
+function makeNode(
+    group: string,
+    kind: string,
+    namespace: string,
+    name: string,
+    parentRefs: Array<{group: string; kind: string; namespace: string; name: string}> = []
+): ResourceNode {
+    return {
+        group,
+        kind,
+        namespace,
+        name,
+        uid: `${group}/${kind}/${namespace}/${name}`,
+        version: 'v1',
+        resourceVersion: '1',
+        parentRefs: parentRefs.map(p => ({
+            ...p,
+            uid: `${p.group}/${p.kind}/${p.namespace}/${p.name}`,
+            version: 'v1'
+        })),
+        info: []
+    };
+}
+
+test('nodeKey returns correct format', () => {
+    expect(nodeKey({group: 'apps', kind: 'Deployment', namespace: 'default', name: 'foo'})).toBe(
+        'apps/Deployment/default/foo'
+    );
+});
+
+test('hasAncestorMatching returns true when direct parent matches', () => {
+    const rollout = makeNode('argoproj.io', 'Rollout', 'default', 'my-rollout');
+    const rs = makeNode('apps', 'ReplicaSet', 'default', 'my-rs', [
+        {group: 'argoproj.io', kind: 'Rollout', namespace: 'default', name: 'my-rollout'}
+    ]);
+    const tree: ApplicationTree = {
+        nodes: [rollout, rs],
+        orphanedNodes: []
+    };
+
+    expect(hasAncestorMatching(rs, tree, 'argoproj.io', 'Rollout')).toBe(true);
+});
+
+test('hasAncestorMatching returns true when ancestor two levels up matches', () => {
+    const rollout = makeNode('argoproj.io', 'Rollout', 'default', 'my-rollout');
+    const rs = makeNode('apps', 'ReplicaSet', 'default', 'my-rs', [
+        {group: 'argoproj.io', kind: 'Rollout', namespace: 'default', name: 'my-rollout'}
+    ]);
+    const pod = makeNode('', 'Pod', 'default', 'my-pod', [
+        {group: 'apps', kind: 'ReplicaSet', namespace: 'default', name: 'my-rs'}
+    ]);
+    const tree: ApplicationTree = {
+        nodes: [rollout, rs, pod],
+        orphanedNodes: []
+    };
+
+    expect(hasAncestorMatching(pod, tree, 'argoproj.io', 'Rollout')).toBe(true);
+});
+
+test('hasAncestorMatching returns false when no ancestor matches', () => {
+    const rs = makeNode('apps', 'ReplicaSet', 'default', 'my-rs', [
+        {group: 'apps', kind: 'Deployment', namespace: 'default', name: 'my-deploy'}
+    ]);
+    const tree: ApplicationTree = {
+        nodes: [rs],
+        orphanedNodes: []
+    };
+
+    expect(hasAncestorMatching(rs, tree, 'argoproj.io', 'Rollout')).toBe(false);
+});
+
+test('hasAncestorMatching returns false when node has no parentRefs', () => {
+    const rollout = makeNode('argoproj.io', 'Rollout', 'default', 'my-rollout');
+    const tree: ApplicationTree = {
+        nodes: [rollout],
+        orphanedNodes: []
+    };
+
+    expect(hasAncestorMatching(rollout, tree, 'argoproj.io', 'Rollout')).toBe(false);
+});
+
+test('hasAncestorMatching handles missing parent in tree', () => {
+    const rs = makeNode('apps', 'ReplicaSet', 'default', 'my-rs', [
+        {group: 'argoproj.io', kind: 'Rollout', namespace: 'default', name: 'nonexistent-rollout'}
+    ]);
+    const tree: ApplicationTree = {
+        nodes: [rs],
+        orphanedNodes: []
+    };
+
+    expect(hasAncestorMatching(rs, tree, 'argoproj.io', 'Rollout')).toBe(false);
+});
+
+test('hasAncestorMatching handles circular parentRefs', () => {
+    const nodeA = makeNode('apps', 'A', 'default', 'a', [
+        {group: 'apps', kind: 'B', namespace: 'default', name: 'b'}
+    ]);
+    const nodeB = makeNode('apps', 'B', 'default', 'b', [
+        {group: 'apps', kind: 'A', namespace: 'default', name: 'a'}
+    ]);
+    const tree: ApplicationTree = {
+        nodes: [nodeA, nodeB],
+        orphanedNodes: []
+    };
+
+    expect(hasAncestorMatching(nodeA, tree, 'argoproj.io', 'Rollout')).toBe(false);
+});
+
+test('hasAncestorMatching includes orphanedNodes when building nodeByKey', () => {
+    const orphanedRollout = makeNode('argoproj.io', 'Rollout', 'default', 'orphaned-rollout');
+    const rs = makeNode('apps', 'ReplicaSet', 'default', 'my-rs', [
+        {group: 'argoproj.io', kind: 'Rollout', namespace: 'default', name: 'orphaned-rollout'}
+    ]);
+    const tree: ApplicationTree = {
+        nodes: [rs],
+        orphanedNodes: [orphanedRollout]
+    };
+
+    expect(hasAncestorMatching(rs, tree, 'argoproj.io', 'Rollout')).toBe(true);
+});

--- a/ui/src/app/shared/services/extensions-service-helpers.ts
+++ b/ui/src/app/shared/services/extensions-service-helpers.ts
@@ -1,0 +1,56 @@
+import * as minimatch from 'minimatch';
+
+import {ApplicationTree, ResourceNode} from '../models';
+
+export function nodeKey(ref: {group: string; kind: string; namespace: string; name: string}): string {
+    return [ref.group, ref.kind, ref.namespace, ref.name].join('/');
+}
+
+/**
+ * Returns true if any ancestor of the given node matches the specified group and kind.
+ * Walks parentRefs recursively, resolving parents from tree.nodes and tree.orphanedNodes.
+ * Tracks visited keys to avoid circular refs. Skips missing parents.
+ */
+export function hasAncestorMatching(
+    node: ResourceNode,
+    tree: ApplicationTree,
+    group: string,
+    kind: string
+): boolean {
+    const allNodes = [...(tree.nodes || []), ...(tree.orphanedNodes || [])];
+    const nodeByKey = new Map<string, ResourceNode>();
+    allNodes.forEach(n => nodeByKey.set(nodeKey(n), n));
+
+    const visited = new Set<string>();
+    const queue: ResourceNode[] = [node];
+
+    while (queue.length > 0) {
+        const current = queue.shift()!;
+        const currentKey = nodeKey(current);
+
+        if (visited.has(currentKey)) {
+            continue;
+        }
+        visited.add(currentKey);
+
+        for (const parentRef of current.parentRefs || []) {
+            const parentKey = nodeKey(parentRef);
+            if (visited.has(parentKey)) {
+                continue;
+            }
+
+            const parent = nodeByKey.get(parentKey);
+            if (!parent) {
+                continue;
+            }
+
+            if (minimatch(parent.group, group) && minimatch(parent.kind, kind)) {
+                return true;
+            }
+
+            queue.push(parent);
+        }
+    }
+
+    return false;
+}

--- a/ui/src/app/shared/services/extensions-service.ts
+++ b/ui/src/app/shared/services/extensions-service.ts
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import * as minimatch from 'minimatch';
 
-import {Application, ApplicationTree, State} from '../models';
+import {Application, ApplicationTree, ResourceNode, State} from '../models';
+import {hasAncestorMatching} from './extensions-service-helpers';
 
 type ExtensionsEventType = 'resource' | 'systemLevel' | 'appView' | 'statusPanel' | 'topBar';
 type ExtensionsType = ResourceTabExtension | SystemLevelExtension | AppViewExtension | StatusPanelExtension | TopBarActionMenuExt;
@@ -38,8 +39,14 @@ const extensions = {
     topBarActionMenuExts: new Array<TopBarActionMenuExt>()
 };
 
-function registerResourceExtension(component: ExtensionComponent, group: string, kind: string, tabTitle: string, opts?: {icon: string}) {
-    const ext = {component, group, kind, title: tabTitle, icon: opts?.icon};
+function registerResourceExtension(
+    component: ExtensionComponent,
+    group: string,
+    kind: string,
+    tabTitle: string,
+    opts?: {icon?: string; matchOnAncestors?: boolean}
+) {
+    const ext = {component, group, kind, title: tabTitle, icon: opts?.icon, matchOnAncestors: opts?.matchOnAncestors};
     extensions.resourceExtentions.push(ext);
     extensions.eventTarget.emit('resource', ext);
 }
@@ -96,6 +103,7 @@ export interface ResourceTabExtension {
     kind: string;
     component: ExtensionComponent;
     icon?: string;
+    matchOnAncestors?: boolean;
 }
 
 export interface SystemLevelExtension {
@@ -183,9 +191,25 @@ export class ExtensionsService {
         extensions.eventTarget.removeEventListener(evtType, cb);
     }
 
-    public getResourceTabs(group: string, kind: string): ResourceTabExtension[] {
+    public getResourceTabs(
+        group: string,
+        kind: string,
+        tree?: ApplicationTree,
+        selectedNode?: ResourceNode
+    ): ResourceTabExtension[] {
         initLegacyExtensions();
-        const items = extensions.resourceExtentions.filter(extension => minimatch(group, extension.group) && minimatch(kind, extension.kind)).slice();
+        const items = extensions.resourceExtentions.filter(extension => {
+            const directMatch = minimatch(group, extension.group) && minimatch(kind, extension.kind);
+            if (directMatch) return true;
+            if (extension.matchOnAncestors && tree && selectedNode) {
+                try {
+                    return hasAncestorMatching(selectedNode, tree, extension.group, extension.kind);
+                } catch {
+                    return false;
+                }
+            }
+            return false;
+        }).slice();
         return items.sort((a, b) => a.title.localeCompare(b.title));
     }
 


### PR DESCRIPTION
## Summary

Add opt-in `matchOnAncestors` support to Resource Tab UI extensions, allowing extensions to activate when the selected resource is a **descendant** of a resource matching the extension's group/kind — not just on a direct match. This is fully backwards compatible; existing extensions are unaffected.

**Motivation:** Extensions like Argo Rollouts currently only show their tab when the exact resource (e.g. a Rollout) is selected. With `matchOnAncestors: true`, the tab also appears when viewing child resources like ReplicaSets or Pods owned by that Rollout, giving users contextual extension info without navigating back up the tree.

## Changes

- **New helper module** (`extensions-service-helpers.ts`): Adds `nodeKey` and `hasAncestorMatching` utilities that walk `parentRefs` up the resource tree (including orphaned nodes), with circular-ref protection and graceful handling of missing parents.
- **Extended `registerResourceExtension` API**: The `opts` parameter now accepts `matchOnAncestors?: boolean` alongside the existing `icon` option.
- **Updated `getResourceTabs`**: Accepts optional `tree` and `selectedNode` parameters. When provided, extensions with `matchOnAncestors: true` also match if any ancestor of the selected node matches the extension's group/kind (with try/catch fallback to direct-match-only on error).
- **Updated call site** (`resource-details.tsx`): Passes `tree` and `selectedNode` through to `getResourceTabs`.
- **Unit tests** (`extensions-service-helpers.test.ts`): Covers direct parent match, multi-level ancestor match, no match, no parentRefs, missing parent in tree, circular refs, and orphaned node resolution.
- **Documentation**: Updated `ui-extensions.md` with the new option in the API signature, a description of the behavior, and an example showing a Rollout extension with `matchOnAncestors: true`.
- **Design & plan docs**: Added design doc and implementation plan under `docs/plans/`.

## Test Plan

- [x] Unit tests for `hasAncestorMatching`: direct parent, two-level ancestor, no match, no parentRefs, missing parent, circular refs, orphaned nodes
- [ ] Manual verification: register a test extension with `matchOnAncestors: true` for a Rollout and confirm the tab appears when selecting the Rollout, its ReplicaSet, and its Pod
- [ ] Verify existing extensions (without `matchOnAncestors`) behave identically to before